### PR TITLE
ELE-480: Add data initialization check to cache requests

### DIFF
--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -82,8 +82,11 @@ export default class Autocomplete extends Base {
     super.connectedCallback();
 
     window.addEventListener(AUTOCOMPLETE_RESPONSE, this.receivedResults);
-    window.addEventListener(this.initialDataResponseEventName, this.receiveInitialData);
-    this.requestInitialData();
+
+    if (!this._initialized) {
+      window.addEventListener(this.initialDataResponseEventName, this.receiveInitialData);
+      this.requestInitialData();
+    }
 
     const role = this.getAttribute('role');
     const roles = role ? role.split(' ') : [];

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -181,13 +181,17 @@ export default class Autocomplete extends Base {
 
   /**
    * Receives an event for populating initial data.
+   * Will not populate if the component has already received data
+   * from another source.
    * Intended to be used on mount of this component.
    *
    * @param event The event object.
    */
   receiveInitialData(event: CustomEvent<CacheResponsePayload>): void {
     const data = event.detail.data || {};
-    this.results = data.results || [];
+    if (!this._initialized) {
+      this.results = data.results || [];
+    };
   }
 
   /**

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -35,9 +35,7 @@ export default class Autocomplete extends Base {
   /**
    * Autocomplete request results.
    */
-  @dataInitializer('_initialized')
-  @property({ type: Array })
-  results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
+  @dataInitializer() @property({ type: Array })results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
 
   /**
    * The text to use in the header.

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -123,22 +123,9 @@ export default class Autocomplete extends Base {
    */
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    console.log('in disconnectedCallback')
     window.removeEventListener(AUTOCOMPLETE_RESPONSE, this.receivedResults);
     window.removeEventListener(this.initialDataResponseEventName, this.receiveInitialData);
-  }
-
-  /**
-   * Synchronizes property values when attributes change.
-   *
-   * @param name Name of the property.
-   * @param oldVal The old value of the property.
-   * @param newVal The new value of the property.
-   */
-  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
-    super.attributeChangedCallback(name, oldVal, newVal);
-    if (name === 'results') {
-    //   this._initialized = true;
-    }
   }
 
   /**
@@ -146,16 +133,12 @@ export default class Autocomplete extends Base {
    * The changes to the following properties are listened for:
    *
    * - `selectedIndex`
-   * - `results`
    *
    * @param changedProps A map of the all the changed properties.
    */
   updated(changedProps: PropertyValues): void {
     if (changedProps.has('selectedIndex')) {
       this.dispatchSelectedTerm();
-    }
-    if (changedProps.has('results')) {
-      this._initialized = true;
     }
   }
 

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -136,7 +136,7 @@ export default class Autocomplete extends Base {
     super.attributeChangedCallback(name, oldVal, newVal);
     if (name === 'results') {
       this._initialized = true;
-    };
+    }
   }
 
   /**
@@ -194,7 +194,7 @@ export default class Autocomplete extends Base {
     const data = event.detail.data || {};
     if (!this._initialized) {
       this.results = data.results || [];
-    };
+    }
   }
 
   /**

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -85,7 +85,6 @@ export default class Autocomplete extends Base {
 
     window.addEventListener(AUTOCOMPLETE_RESPONSE, this.receivedResults);
 
-    // eslint-disable-next-line no-underscore-dangle
     if (!this._initialized) {
       window.addEventListener(this.initialDataResponseEventName, this.receiveInitialData);
       this.requestInitialData();
@@ -181,7 +180,6 @@ export default class Autocomplete extends Base {
    */
   receiveInitialData(event: CustomEvent<CacheResponsePayload>): void {
     const data = event.detail.data || {};
-    // eslint-disable-next-line no-underscore-dangle
     if (!this._initialized) {
       this.results = data.results || [];
     }

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -144,12 +144,16 @@ export default class Autocomplete extends Base {
    * The changes to the following properties are listened for:
    *
    * - `selectedIndex`
+   * - `results`
    *
    * @param changedProps A map of the all the changed properties.
    */
   updated(changedProps: PropertyValues): void {
     if (changedProps.has('selectedIndex')) {
       this.dispatchSelectedTerm();
+    }
+    if (changedProps.has('results')) {
+      this._initialized = true;
     }
   }
 

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -123,6 +123,20 @@ export default class Autocomplete extends Base {
   }
 
   /**
+   * Synchronizes property values when attributes change.
+   *
+   * @param name Name of the property.
+   * @param oldVal The old value of the property.
+   * @param newVal The new value of the property.
+   */
+  attributeChangedCallback(name: string, oldVal: any, newVal: any): void {
+    super.attributeChangedCallback(name, oldVal, newVal);
+    if (name === 'results') {
+      this._initialized = true;
+    };
+  }
+
+  /**
    * Reacts to changes to various properties.
    * The changes to the following properties are listened for:
    *

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -23,7 +23,7 @@ import {
   UpdateSearchTermPayload,
 } from '@groupby/elements-events';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import { Base } from '@groupby/elements-base';
+import { Base, dataInitializer } from '@groupby/elements-base';
 
 /**
  * The `gbe-autocomplete` component is responsible for displaying a list
@@ -35,7 +35,9 @@ export default class Autocomplete extends Base {
   /**
    * Autocomplete request results.
    */
-  @property({ type: Array }) results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
+  @dataInitializer('_initialized')
+  @property({ type: Array })
+  results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
 
   /**
    * The text to use in the header.
@@ -135,7 +137,7 @@ export default class Autocomplete extends Base {
   attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
     super.attributeChangedCallback(name, oldVal, newVal);
     if (name === 'results') {
-      this._initialized = true;
+    //   this._initialized = true;
     }
   }
 

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -123,7 +123,6 @@ export default class Autocomplete extends Base {
    */
   disconnectedCallback(): void {
     super.disconnectedCallback();
-    console.log('in disconnectedCallback')
     window.removeEventListener(AUTOCOMPLETE_RESPONSE, this.receivedResults);
     window.removeEventListener(this.initialDataResponseEventName, this.receiveInitialData);
   }

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -132,7 +132,7 @@ export default class Autocomplete extends Base {
    * @param oldVal The old value of the property.
    * @param newVal The new value of the property.
    */
-  attributeChangedCallback(name: string, oldVal: any, newVal: any): void {
+  attributeChangedCallback(name: string, oldVal: string | null, newVal: string | null): void {
     super.attributeChangedCallback(name, oldVal, newVal);
     if (name === 'results') {
       this._initialized = true;

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -170,8 +170,7 @@ export default class Autocomplete extends Base {
 
   /**
    * Receives an event for populating initial data.
-   * Will not populate if the component has already received data
-   * from another source.
+   * This function will do nothing if the component had previously received data.
    * Intended to be used on mount of this component.
    *
    * @param event The event object.

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -85,6 +85,7 @@ export default class Autocomplete extends Base {
 
     window.addEventListener(AUTOCOMPLETE_RESPONSE, this.receivedResults);
 
+    // eslint-disable-next-line no-underscore-dangle
     if (!this._initialized) {
       window.addEventListener(this.initialDataResponseEventName, this.receiveInitialData);
       this.requestInitialData();
@@ -180,6 +181,7 @@ export default class Autocomplete extends Base {
    */
   receiveInitialData(event: CustomEvent<CacheResponsePayload>): void {
     const data = event.detail.data || {};
+    // eslint-disable-next-line no-underscore-dangle
     if (!this._initialized) {
       this.results = data.results || [];
     }

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -35,7 +35,7 @@ export default class Autocomplete extends Base {
   /**
    * Autocomplete request results.
    */
-  @dataInitializer() @property({ type: Array })results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
+  @dataInitializer() @property({ type: Array }) results: AutocompleteResultGroup<AutocompleteSearchTermItem>[] = [];
 
   /**
    * The text to use in the header.

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -177,10 +177,9 @@ export default class Autocomplete extends Base {
    * @param event The event object.
    */
   receiveInitialData(event: CustomEvent<CacheResponsePayload>): void {
+    if (this._initialized) return;
     const data = event.detail.data || {};
-    if (!this._initialized) {
-      this.results = data.results || [];
-    }
+    this.results = data.results || [];
   }
 
   /**

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -221,6 +221,14 @@ describe('Autcomplete Component', () => {
         expect(dispatchSelectedTerm).to.be.called;
       });
     });
+
+    describe('results', () => {
+      it('should set the initialized property to true', () => {
+        autocomplete.updated(new Map([['results', 'autocomplete results']]));
+
+        expect(autocomplete._initialized).to.be.true;
+      });
+    });
   });
 
   describe('itemCount', () => {

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -164,6 +164,24 @@ describe('Autcomplete Component', () => {
     });
   });
 
+  describe('attributeChangedCallback()', () => {
+    let results;
+
+    beforeEach(() => {
+      results = JSON.stringify([
+        { title: 'Brands', items: [{ label: 'Cats' }, { label: 'Dogs' }] },
+        { title: 'default', items: [{ label: 'Cars' }, { label: 'Bikes' }] },
+      ])
+    });
+    itShouldCallParentMethod(() => autocomplete, 'attributeChangedCallback');
+
+    it('should set _initialized to true when the component receives its results', () => {
+      autocomplete.attributeChangedCallback('results', [], results)
+
+      expect(autocomplete._initialized).to.be.true;
+    });
+  });
+
   describe('updated()', () => {
     describe('selectedIndex', () => {
       it('should dispatch an AUTOCOMPLETE_ACTIVE_TERM event', () => {

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -192,24 +192,6 @@ describe('Autcomplete Component', () => {
     });
   });
 
-  describe('attributeChangedCallback()', () => {
-    let results;
-
-    beforeEach(() => {
-      results = JSON.stringify([
-        { title: 'Brands', items: [{ label: 'Cats' }, { label: 'Dogs' }] },
-        { title: 'default', items: [{ label: 'Cars' }, { label: 'Bikes' }] },
-      ])
-    });
-    itShouldCallParentMethod(() => autocomplete, 'attributeChangedCallback');
-
-    it('should set _initialized to true when the component receives its results', () => {
-      autocomplete.attributeChangedCallback('results', [], results)
-
-      expect(autocomplete._initialized).to.be.true;
-    });
-  });
-
   describe('updated()', () => {
     describe('selectedIndex', () => {
       it('should dispatch an AUTOCOMPLETE_ACTIVE_TERM event', () => {
@@ -219,14 +201,6 @@ describe('Autcomplete Component', () => {
         autocomplete.updated(new Map([['selectedIndex', 0]]));
 
         expect(dispatchSelectedTerm).to.be.called;
-      });
-    });
-
-    describe('results', () => {
-      it('should set the initialized property to true', () => {
-        autocomplete.updated(new Map([['results', 'autocomplete results']]));
-
-        expect(autocomplete._initialized).to.be.true;
       });
     });
   });

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -130,18 +130,34 @@ describe('Autcomplete Component', () => {
   });
 
   describe('receiveInitialData()', () => {
+    let cacheResults;
+    let cacheResponseEvent;
+
+    beforeEach(() => {
+      cacheResults = [{
+        items: [
+          { label: 'dress' },
+          { label: 'black dress' },
+          { label: 'long dress' },
+        ],
+        title: '',
+      }];
+      cacheResponseEvent = { detail: { data: { results: cacheResults } } };
+    });
+
     it('should set initial data given an event', () => {
-      // const cacheResponseEvent = new CustomEvent();
-      const items = [
-        { label: 'dress' },
-        { label: 'black dress' },
-        { label: 'long dress' },
-      ];
-      const cacheResponseEvent = { detail: { data: { results: [{ items, title: '' }] } } };
+      autocomplete.receiveInitialData(cacheResponseEvent);
+
+      expect(autocomplete.results).to.deep.equal(cacheResults);
+    });
+
+    it('should not set the initial data if Autocomplete has already been initialized', () => {
+      autocomplete._initialized = true;
+      const results = autocomplete.results = ['results'];
 
       autocomplete.receiveInitialData(cacheResponseEvent);
 
-      expect(autocomplete.results).to.deep.equal(cacheResponseEvent.detail.data.results);
+      expect(autocomplete.results).to.deep.equal(results);
     });
   });
 

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -92,6 +92,18 @@ describe('Autcomplete Component', () => {
       expect(requestInitialData).to.be.called;
     });
 
+    it('should not request initial data if the component is already initialized', () => {
+      autocomplete._initialized = true;
+
+      autocomplete.connectedCallback();
+
+      expect(windowAddEventListener).to.not.be.calledWith(
+        returnEvent,
+        autocomplete.receiveInitialData
+      );
+      expect(requestInitialData).to.not.be.called;
+    });
+
     describe('role attribute', () => {
       it('should add the listbox role', () => {
         autocomplete.connectedCallback();

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -22,16 +22,16 @@ export default abstract class Base extends LitElement {
 }
 
 export function dataInitializer(initialized: string): PropertyDecorator {
-  return function(target: Record<string, any>, propertyName: string): void {
-    console.log('initializer props', target, propertyName);
+  return function(target: object, propertyName: string): void {
     const oldDescriptor = Object.getOwnPropertyDescriptor(target, 'results');
+    const instanceMap = new WeakMap();
     function decoratedSetter(newVal: any): void {
-      console.log('decoratedSetter');
-      console.log('target results', this[propertyName]);
-      console.log(`target ${initialized} value in setter`, this[initialized]);
-      console.log('results new value in setter', newVal);
       oldDescriptor.set.call(this, newVal);
-      this[initialized] = true;
+      if (instanceMap.get(this)) {
+        this[initialized] = true;
+      } else {
+        instanceMap.set(this, true);
+      }
     }
 
     Object.defineProperty(target, propertyName, { ...oldDescriptor, set: decoratedSetter });

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -21,6 +21,13 @@ export default abstract class Base extends LitElement {
   }
 }
 
+/**
+ * A property decorator that will set the data initialization state in a class.
+ * It will extend the property's setter to set the initialization state to true.
+ * This expects that the property already has defined accessors and a default value.
+ *
+ * @param initialized The name of the initialization property.
+ */
 export function dataInitializer(initialized: string): PropertyDecorator {
   // eslint-disable-next-line func-names
   return function(target: object, propertyName: string): void {

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -26,9 +26,10 @@ export default abstract class Base extends LitElement {
  * It will extend the property's setter to set the initialization state to true.
  * This expects that the property already has defined accessors and a default value.
  *
- * @param initialized The name of the initialization property.
+ * @param initProperty The name of the initialization property. Has a default value
+ * of "_initialized".
  */
-export function dataInitializer(initialized: string): PropertyDecorator {
+export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
   // eslint-disable-next-line func-names
   return function(target: object, propertyName: string): void {
     const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);
@@ -37,7 +38,7 @@ export function dataInitializer(initialized: string): PropertyDecorator {
     function decoratedSetter(newVal: any): void {
       oldDescriptor.set.call(this, newVal);
       if (instanceMap.get(this)) {
-        this[initialized] = true;
+        this[initProperty] = true;
       } else {
         instanceMap.set(this, true);
       }

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -29,8 +29,7 @@ export default abstract class Base extends LitElement {
  * @param initProperty The name of the initialization property.
  */
 export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
-  // eslint-disable-next-line func-names
-  return function(target: object, propertyName: string): void {
+  return (target: object, propertyName: string): void => {
     const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);
     const instanceMap = new WeakMap();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -22,9 +22,11 @@ export default abstract class Base extends LitElement {
 }
 
 export function dataInitializer(initialized: string): PropertyDecorator {
+  // eslint-disable-next-line func-names
   return function(target: object, propertyName: string): void {
     const oldDescriptor = Object.getOwnPropertyDescriptor(target, 'results');
     const instanceMap = new WeakMap();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function decoratedSetter(newVal: any): void {
       oldDescriptor.set.call(this, newVal);
       if (instanceMap.get(this)) {

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -20,28 +20,3 @@ export default abstract class Base extends LitElement {
     return this.dispatchEvent(eventToDispatch);
   }
 }
-
-/**
- * A property decorator that will set the data initialization state in a class.
- * It will extend the property's setter to set the initialization state to true.
- * This expects that the property already has defined accessors and a default value.
- *
- * @param initProperty The name of the initialization property.
- */
-export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
-  return (target: object, propertyName: string): void => {
-    const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);
-    const instanceMap = new WeakMap();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function decoratedSetter(newVal: any): void {
-      oldDescriptor.set.call(this, newVal);
-      if (instanceMap.get(this)) {
-        this[initProperty] = true;
-      } else {
-        instanceMap.set(this, true);
-      }
-    }
-
-    Object.defineProperty(target, propertyName, { ...oldDescriptor, set: decoratedSetter });
-  };
-}

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -6,6 +6,11 @@ import {
  * A base component for all GB Elements components to extend. It is based on LitElement.
  */
 export default abstract class Base extends LitElement {
+  /**
+   * Determines whether or not the component has received its initial set of data.
+   */
+  protected _initialized: boolean = false;
+
   createRenderRoot(): Element | ShadowRoot {
     return this;
   }

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -26,8 +26,7 @@ export default abstract class Base extends LitElement {
  * It will extend the property's setter to set the initialization state to true.
  * This expects that the property already has defined accessors and a default value.
  *
- * @param initProperty The name of the initialization property. Has a default value
- * of "_initialized".
+ * @param initProperty The name of the initialization property.
  */
 export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
   // eslint-disable-next-line func-names

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -20,3 +20,20 @@ export default abstract class Base extends LitElement {
     return this.dispatchEvent(eventToDispatch);
   }
 }
+
+export function dataInitializer(initialized: string): PropertyDecorator {
+  return function(target: Record<string, any>, propertyName: string): void {
+    console.log('initializer props', target, propertyName);
+    const oldDescriptor = Object.getOwnPropertyDescriptor(target, 'results');
+    function decoratedSetter(newVal: any): void {
+      console.log('decoratedSetter');
+      console.log('target results', this[propertyName]);
+      console.log(`target ${initialized} value in setter`, this[initialized]);
+      console.log('results new value in setter', newVal);
+      oldDescriptor.set.call(this, newVal);
+      this[initialized] = true;
+    }
+
+    Object.defineProperty(target, propertyName, { ...oldDescriptor, set: decoratedSetter });
+  };
+}

--- a/packages/web-components/@groupby/elements-base/src/base.ts
+++ b/packages/web-components/@groupby/elements-base/src/base.ts
@@ -31,7 +31,7 @@ export default abstract class Base extends LitElement {
 export function dataInitializer(initialized: string): PropertyDecorator {
   // eslint-disable-next-line func-names
   return function(target: object, propertyName: string): void {
-    const oldDescriptor = Object.getOwnPropertyDescriptor(target, 'results');
+    const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);
     const instanceMap = new WeakMap();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function decoratedSetter(newVal: any): void {

--- a/packages/web-components/@groupby/elements-base/src/decorators.ts
+++ b/packages/web-components/@groupby/elements-base/src/decorators.ts
@@ -1,0 +1,25 @@
+/**
+ * A property decorator that will set the data initialization state in a class.
+ * It will extend the property's setter to set the initialization state to true.
+ * This expects that the property already has defined accessors and a default value.
+ *
+ * @param initProperty The name of the initialization property.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
+  return (target: object, propertyName: string): void => {
+    const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);
+    const instanceMap = new WeakMap();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function decoratedSetter(newVal: any): void {
+      oldDescriptor.set.call(this, newVal);
+      if (instanceMap.get(this)) {
+        this[initProperty] = true;
+      } else {
+        instanceMap.set(this, true);
+      }
+    }
+
+    Object.defineProperty(target, propertyName, { ...oldDescriptor, set: decoratedSetter });
+  };
+}

--- a/packages/web-components/@groupby/elements-base/src/decorators.ts
+++ b/packages/web-components/@groupby/elements-base/src/decorators.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
 /**
  * A property decorator that will set the data initialization state in a class.
  * It will extend the property's setter to set the initialization state to true.
@@ -5,7 +7,6 @@
  *
  * @param initProperty The name of the initialization property.
  */
-// eslint-disable-next-line import/prefer-default-export
 export function dataInitializer(initProperty: string = '_initialized'): PropertyDecorator {
   return (target: object, propertyName: string): void => {
     const oldDescriptor = Object.getOwnPropertyDescriptor(target, propertyName);

--- a/packages/web-components/@groupby/elements-base/src/index.ts
+++ b/packages/web-components/@groupby/elements-base/src/index.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as Base } from './base';
+export { default as Base, dataInitializer } from './base';

--- a/packages/web-components/@groupby/elements-base/src/index.ts
+++ b/packages/web-components/@groupby/elements-base/src/index.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
-export { default as Base, dataInitializer } from './base';
+export { default as Base } from './base';
+export { dataInitializer } from './decorators';

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -1,4 +1,4 @@
-import { expect, stub, spy } from '../utils';
+import { expect, spy, stub } from '../utils';
 import { DummyComponent } from './dummy-component';
 import { dataInitializer } from '../../src';
 

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -51,7 +51,7 @@ describe('dataInitializer decorator', () => {
     Object.defineProperty(
       testObj2,
       testPropertyName,
-      Object.getOwnPropertyDescriptor(testObj, 'results'),
+      Object.getOwnPropertyDescriptor(testObj, 'results')
     );
     dataInitializer('init')(testObj, testPropertyName);
     dataInitializer('init')(testObj2, testPropertyName);
@@ -68,7 +68,12 @@ describe('dataInitializer decorator', () => {
 
     dataInitializer('init')(testObj, testPropertyName);
     const newDescriptor = Object.getOwnPropertyDescriptor(testObj, testPropertyName);
-    const { get, set, enumerable, configurable } = newDescriptor
+    const {
+      get,
+      set,
+      enumerable,
+      configurable
+    } = newDescriptor;
 
     expect(set).to.not.equal(originalDescriptor.set);
     expect(get).to.equal(originalDescriptor.get);

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -1,5 +1,48 @@
-import { expect, stub } from '../utils';
+import { expect, stub, spy } from '../utils';
 import { DummyComponent } from './dummy-component';
+import { dataInitializer } from '../../src';
+
+describe.only('dataInitializer decorator', () => {
+  const testPropertyName = 'results';
+  let testObj;
+
+  beforeEach(() => {
+    testObj = {
+      init: false,
+      get results() {
+        return this._results;
+      },
+      set results(val) {
+        this._results = val;
+      },
+      _results: ['a', 'b'],
+    };
+  });
+
+  it('should extend a property setter', () => {
+    const originalSet = spy(testObj, 'results', ['set']);
+
+    dataInitializer('init')(testObj, testPropertyName);
+    testObj.results = ['c', 'd'];
+
+    expect(originalSet.set).to.be.called;
+    expect(testObj.init).to.be.true;
+    expect(testObj.results).to.deep.equal(['c', 'd']);
+  });
+
+  it('should only modify the set function of the property descriptor', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(testObj, testPropertyName);
+
+    dataInitializer('init')(testObj, testPropertyName);
+    const newDescriptor = Object.getOwnPropertyDescriptor(testObj, testPropertyName);
+    const { get, set, enumerable, configurable } = newDescriptor
+
+    expect(set).to.not.equal(originalDescriptor.set);
+    expect(get).to.equal(originalDescriptor.get);
+    expect(enumerable).to.equal(originalDescriptor.enumerable);
+    expect(configurable).to.equal(originalDescriptor.configurable);
+  });
+});
 
 describe('Base Class', () => {
   let dummyComponent;

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -72,7 +72,7 @@ describe('dataInitializer decorator', () => {
       get,
       set,
       enumerable,
-      configurable
+      configurable,
     } = newDescriptor;
 
     expect(set).to.not.equal(originalDescriptor.set);

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -26,8 +26,39 @@ describe.only('dataInitializer decorator', () => {
     testObj.results = ['c', 'd'];
 
     expect(originalSet.set).to.be.called;
-    expect(testObj.init).to.be.true;
     expect(testObj.results).to.deep.equal(['c', 'd']);
+  });
+
+  it('should not set the initialize property to true on the first set call', () => {
+    dataInitializer('init')(testObj, testPropertyName);
+    testObj.results = ['c', 'd'];
+
+    expect(testObj.init).to.be.false;
+  });
+
+  it('should not set the initialize property to true on the first set call', () => {
+    dataInitializer('init')(testObj, testPropertyName);
+    testObj.results = ['c', 'd'];
+    testObj.results = ['e', 'f'];
+
+    expect(testObj.init).to.be.true;
+  });
+
+  it('should store the initialization states between multiple instances of the component', () => {
+    const testObj2 = Object.assign({}, testObj);
+    Object.defineProperty(
+      testObj2,
+      testPropertyName,
+      Object.getOwnPropertyDescriptor(testObj, 'results'),
+    );
+
+    dataInitializer('init')(testObj, testPropertyName);
+    dataInitializer('init')(testObj2, testPropertyName);
+    testObj.results = ['c', 'd'];
+    testObj.results = ['e', 'f'];
+
+    expect(testObj.init).to.be.true;
+    expect(testObj2.init).to.be.false;
   });
 
   it('should only modify the set function of the property descriptor', () => {

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -8,6 +8,14 @@ describe('Base Class', () => {
     dummyComponent = new DummyComponent();
   });
 
+  describe('constructor()', () => {
+    describe('_initialized property', () => {
+      it('should have a default value of false', () => {
+        expect(dummyComponent._initialized).to.be.false;
+      });
+    });
+  });
+
   describe('createRenderRoot', () => {
     it('should return the element itself', () => {
       const renderRoot = dummyComponent.createRenderRoot();

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -47,7 +47,7 @@ describe('dataInitializer decorator', () => {
   });
 
   it('should store the initialization states between multiple instances of the component', () => {
-    const testObj2 = Object.assign({}, testObj);
+    const testObj2 = { ...testObj };
     Object.defineProperty(
       testObj2,
       testPropertyName,

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -2,7 +2,7 @@ import { expect, stub, spy } from '../utils';
 import { DummyComponent } from './dummy-component';
 import { dataInitializer } from '../../src';
 
-describe.only('dataInitializer decorator', () => {
+describe('dataInitializer decorator', () => {
   const testPropertyName = 'results';
   let testObj;
 

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -61,7 +61,7 @@ describe('dataInitializer decorator', () => {
     dataInitializer(initProp)(otherTestObj, testPropertyName);
 
     testObj.results = ['c', 'd'];
-    testObj.results = ['e', 'f']; //sic
+    testObj.results = ['e', 'f']; // sic
 
     expect(testObj.init).to.be.true;
     expect(otherTestObj.init).to.be.false;

--- a/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
+++ b/packages/web-components/@groupby/elements-base/test/unit/base.test.ts
@@ -21,8 +21,8 @@ describe('dataInitializer decorator', () => {
 
   it('should extend a property setter', () => {
     const originalSet = spy(testObj, 'results', ['set']);
-
     dataInitializer('init')(testObj, testPropertyName);
+
     testObj.results = ['c', 'd'];
 
     expect(originalSet.set).to.be.called;
@@ -31,6 +31,7 @@ describe('dataInitializer decorator', () => {
 
   it('should not set the initialize property to true on the first set call', () => {
     dataInitializer('init')(testObj, testPropertyName);
+
     testObj.results = ['c', 'd'];
 
     expect(testObj.init).to.be.false;
@@ -38,6 +39,7 @@ describe('dataInitializer decorator', () => {
 
   it('should not set the initialize property to true on the first set call', () => {
     dataInitializer('init')(testObj, testPropertyName);
+
     testObj.results = ['c', 'd'];
     testObj.results = ['e', 'f'];
 
@@ -51,9 +53,9 @@ describe('dataInitializer decorator', () => {
       testPropertyName,
       Object.getOwnPropertyDescriptor(testObj, 'results'),
     );
-
     dataInitializer('init')(testObj, testPropertyName);
     dataInitializer('init')(testObj2, testPropertyName);
+
     testObj.results = ['c', 'd'];
     testObj.results = ['e', 'f'];
 

--- a/packages/web-components/@groupby/elements-products/src/products-base.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-base.ts
@@ -69,10 +69,12 @@ export default class ProductsBase extends Base {
 
   /**
    * Receives an event for populating initial product data.
+   * Will not populate it if the product data has already been initialized.
    *
    * @param event The event object.
    */
   setProductsFromCacheEvent(event: CustomEvent<CacheResponsePayload>): void {
+    if (this._initialized) return;
     const data = event.detail.data || {};
     this.products = data.products || [];
   }

--- a/packages/web-components/@groupby/elements-products/src/products-base.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-base.ts
@@ -15,7 +15,7 @@ import {
 } from '@groupby/elements-events';
 import * as shortid from 'shortid';
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-import { Base } from '@groupby/elements-base';
+import { Base, dataInitializer } from '@groupby/elements-base';
 
 /**
  * The `gbe-products-base` web component wraps and renders a number of
@@ -27,7 +27,9 @@ export default class ProductsBase extends Base {
   /**
    * The product data to be rendered.
    */
-  @property({ type: Array }) products: Product[] = [];
+  @dataInitializer('_initialize')
+  @property({ type: Array })
+  products: Product[] = [];
 
   /**
    * The name of the event group that this component belongs to.

--- a/packages/web-components/@groupby/elements-products/src/products-base.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-base.ts
@@ -67,7 +67,7 @@ export default class ProductsBase extends Base {
 
   /**
    * Receives an event for populating initial product data.
-   * Will not populate it if the product data has already been initialized.
+   * This function will do nothing if the component had previously received data.
    *
    * @param event The event object.
    */

--- a/packages/web-components/@groupby/elements-products/src/products-base.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-base.ts
@@ -27,9 +27,7 @@ export default class ProductsBase extends Base {
   /**
    * The product data to be rendered.
    */
-  @dataInitializer('_initialize')
-  @property({ type: Array })
-  products: Product[] = [];
+  @dataInitializer() @property({ type: Array })products: Product[] = [];
 
   /**
    * The name of the event group that this component belongs to.

--- a/packages/web-components/@groupby/elements-products/src/products-base.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-base.ts
@@ -27,7 +27,7 @@ export default class ProductsBase extends Base {
   /**
    * The product data to be rendered.
    */
-  @dataInitializer() @property({ type: Array })products: Product[] = [];
+  @dataInitializer() @property({ type: Array }) products: Product[] = [];
 
   /**
    * The name of the event group that this component belongs to.

--- a/packages/web-components/@groupby/elements-products/src/products-sayt.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-sayt.ts
@@ -32,8 +32,10 @@ export default class ProductsSayt extends ProductsBase {
     super.connectedCallback();
 
     window.addEventListener(SAYT_PRODUCTS_RESPONSE, this.setProductsFromProductsEvent);
-    window.addEventListener(this.cacheResponseEventName, this.setProductsFromCacheEvent);
-    this.requestInitialData(SAYT_PRODUCTS_RESPONSE, this.group, this.cacheResponseEventName);
+    if (!this._initialized) {
+      window.addEventListener(this.cacheResponseEventName, this.setProductsFromCacheEvent);
+      this.requestInitialData(SAYT_PRODUCTS_RESPONSE, this.group, this.cacheResponseEventName);
+    }
   }
 
   /**

--- a/packages/web-components/@groupby/elements-products/src/products-search.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-search.ts
@@ -31,8 +31,10 @@ export default class ProductsSearch extends ProductsBase {
   connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener(SEARCH_RESPONSE, this.setProductsFromProductsEvent);
-    window.addEventListener(this.cacheResponseEventName, this.setProductsFromCacheEvent);
-    this.requestInitialData(SEARCH_RESPONSE, this.group, this.cacheResponseEventName);
+    if (!this._initialized) {
+      window.addEventListener(this.cacheResponseEventName, this.setProductsFromCacheEvent);
+      this.requestInitialData(SEARCH_RESPONSE, this.group, this.cacheResponseEventName);
+    }
   }
 
   /**

--- a/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
+++ b/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
@@ -119,9 +119,7 @@ describe('Products Base Component', () => {
 });
 
 describe('Products Sayt Component', () => {
-  const cacheResponseEventName = 'cache-response-event-name';
   let component;
-  let requestInitialData;
 
   beforeEach(() => {
     component = new ProductsSayt();
@@ -130,7 +128,9 @@ describe('Products Sayt Component', () => {
   itShouldExtendClass(() => component, ProductsBase);
 
   describe('connectedCallback', () => {
+    const cacheResponseEventName = 'cache-response-event-name';
     let addEventListener;
+    let requestInitialData;
 
     beforeEach(() => {
       addEventListener = stub(window, 'addEventListener');
@@ -262,18 +262,19 @@ describe('Products Search Component', () => {
   itShouldExtendClass(() => component, ProductsBase);
 
   describe('connectedCallback', () => {
+    const cacheResponseEventName = 'cache-response-event-name';
     let addEventListener;
+    let requestInitialData;
 
     beforeEach(() => {
       addEventListener = stub(window, 'addEventListener');
+      requestInitialData = stub(component, 'requestInitialData');
+      stub(component, 'cacheResponseEventName').get(() => cacheResponseEventName);
     });
 
     itShouldCallParentMethod(() => component, 'connectedCallback');
 
     it('should add event listeners for sayt products events', () => {
-      const cacheResponseEventName = 'cache-response-event-name';
-      stub(component, 'cacheResponseEventName').get(() => cacheResponseEventName);
-
       component.connectedCallback();
 
       expect(addEventListener).to.be.calledWith(
@@ -287,11 +288,21 @@ describe('Products Search Component', () => {
     });
 
     it('should request initial data', () => {
-      const requestInitialData = stub(component, 'requestInitialData');
-
       component.connectedCallback();
 
       expect(requestInitialData).to.be.calledWith(SEARCH_RESPONSE, component.group, component.cacheResponseEventName);
+    });
+
+    it('should not request initial data if it has already been initialized', () => {
+      component._initialized = true;
+
+      component.connectedCallback();
+
+      expect(addEventListener).to.not.be.calledWith(
+        cacheResponseEventName,
+        component.setProductsFromCacheEvent
+      );
+      expect(requestInitialData).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
+++ b/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
@@ -107,7 +107,9 @@ describe('Products Base Component', () => {
 });
 
 describe('Products Sayt Component', () => {
+  const cacheResponseEventName = 'cache-response-event-name';
   let component;
+  let requestInitialData;
 
   beforeEach(() => {
     component = new ProductsSayt();
@@ -120,14 +122,13 @@ describe('Products Sayt Component', () => {
 
     beforeEach(() => {
       addEventListener = stub(window, 'addEventListener');
+      requestInitialData = stub(component, 'requestInitialData');
+      stub(component, 'cacheResponseEventName').get(() => cacheResponseEventName);
     });
 
     itShouldCallParentMethod(() => component, 'connectedCallback');
 
     it('should add event listeners for sayt products events', () => {
-      const cacheResponseEventName = 'cache-response-event-name';
-      stub(component, 'cacheResponseEventName').get(() => cacheResponseEventName);
-
       component.connectedCallback();
 
       expect(addEventListener).to.be.calledWith(
@@ -141,11 +142,21 @@ describe('Products Sayt Component', () => {
     });
 
     it('should request initial data', () => {
-      const requestInitialData = stub(component, 'requestInitialData');
-
       component.connectedCallback();
 
       expect(requestInitialData).to.be.calledWith(SAYT_PRODUCTS_RESPONSE, component.group, component.cacheResponseEventName);
+    });
+
+    it('should not request initial data if it has already been initialized', () => {
+      component._initialized = true;
+
+      component.connectedCallback();
+
+      expect(addEventListener).to.not.be.calledWith(
+        cacheResponseEventName,
+        component.setProductsFromCacheEvent
+      );
+      expect(requestInitialData).to.not.be.called;
     });
   });
 

--- a/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
+++ b/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
@@ -74,8 +74,15 @@ describe('Products Base Component', () => {
   });
 
   describe('setProductsFromCacheEvent', () => {
+    let event;
+    let products;
+
+    beforeEach(() => {
+      products = [1, 2, 3];
+      event = { detail: { data: { products } } };
+    });
     it('should set products to an empty array if the event payload does not contain products', () => {
-      const event = { detail: { data: { products: [] } } };
+      event.detail.data.products = [];
 
       component.setProductsFromCacheEvent(event);
 
@@ -83,12 +90,17 @@ describe('Products Base Component', () => {
     });
 
     it('should set products if given an event payload that contains products', () => {
-      const products = [1, 2, 3];
-      const event = { detail: { data: { products } } };
-
       component.setProductsFromCacheEvent(event);
 
       expect(component.products).to.equal(products);
+    });
+
+    it('should not set products if they have already been inititalized', () => {
+      component._initialized = true;
+
+      component.setProductsFromCacheEvent(event);
+
+      expect(component.products).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
An `_initialized` boolean property was added to `Base` with the intention of being set to true once a component has received data either through a search call or attribute value. This value is checked when reacting to cache responses on whether to use the cache data. 

An accompanying decorator was added to extend a property's set accessor to also set a component's `_initialized` value to true. 