### PR TITLE
ELE-519: Make Search and SAYT products response structure identical

### DIFF
--- a/.storybook/common.ts
+++ b/.storybook/common.ts
@@ -129,9 +129,7 @@ export const generateSearchResponseEvent = (productCount: number, group?: string
   return {
     name: SEARCH_RESPONSE,
     payload: {
-      results: {
-        records: getProducts(productCount)
-      },
+      products: getProducts(productCount),
       group,
     }
   }

--- a/packages/web-components/@groupby/elements-autocomplete/package.json
+++ b/packages/web-components/@groupby/elements-autocomplete/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978",
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065",
     "lit-element": "^2.2.0",
     "shortid": "^2.2.15"
   }

--- a/packages/web-components/@groupby/elements-product/package.json
+++ b/packages/web-components/@groupby/elements-product/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978",
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@groupby/elements-products/package.json
+++ b/packages/web-components/@groupby/elements-products/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978",
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065",
     "lit-element": "^2.2.0",
     "shortid": "^2.2.15"
   }

--- a/packages/web-components/@groupby/elements-products/src/products-search.ts
+++ b/packages/web-components/@groupby/elements-products/src/products-search.ts
@@ -54,7 +54,7 @@ export default class ProductsSearch extends ProductsBase {
     const eventGroup = event.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup === componentGroup) {
-      this.products = event.detail.results.products || [];
+      this.products = event.detail.products || [];
     }
   }
 

--- a/packages/web-components/@groupby/elements-products/stories/index.ts
+++ b/packages/web-components/@groupby/elements-products/stories/index.ts
@@ -142,7 +142,7 @@ storiesOf('Components|Products', module)
       customEvents: [generateSearchResponseEvent(15)],
       notes: {
         markdown: `
-          # GroupBy Elements Products Sayt Component
+          # GroupBy Elements Products Component
 
           [Package README](https://github.com/groupby/elements-view/tree/master/packages/web-components/%40elements/products "GroupBy Elements Products README").
 

--- a/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
+++ b/packages/web-components/@groupby/elements-products/test/unit/products.test.ts
@@ -316,7 +316,7 @@ describe('Products Search Component', () => {
     });
 
     it('should set products when the event matches the group in the component', () => {
-      const event = { detail: { results: { products }, group } };
+      const event = { detail: { products, group } };
       component.group = group;
 
       component.setProductsFromProductsEvent(event);
@@ -325,7 +325,7 @@ describe('Products Search Component', () => {
     });
 
     it('should not set products when the group in the component and event do not match', () => {
-      const event = { detail: { results: { products }, group } };
+      const event = { detail: { products, group } };
 
       component.setProductsFromProductsEvent(event);
 
@@ -333,7 +333,7 @@ describe('Products Search Component', () => {
     });
 
     it('should default the group in the event to an empty string if it is falsey', () => {
-      const event = { detail: { results: { products } } };
+      const event = { detail: { products } };
 
       component.setProductsFromProductsEvent(event);
 
@@ -342,7 +342,7 @@ describe('Products Search Component', () => {
 
     it('should default the group in the component to an empty string if it is falsey', () => {
       component.group = undefined;
-      const event = { detail: { results: { products } } };
+      const event = { detail: { products } };
 
       component.setProductsFromProductsEvent(event);
 

--- a/packages/web-components/@groupby/elements-sayt/package.json
+++ b/packages/web-components/@groupby/elements-sayt/package.json
@@ -28,7 +28,7 @@
     "html-entities": "^1.2.1"
   },
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978",
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065",
     "@types/debounce": "^1.2.0",
     "debounce": "^1.2.0",
     "lit-element": "^2.2.0",

--- a/packages/web-components/@groupby/elements-search-box/package.json
+++ b/packages/web-components/@groupby/elements-search-box/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@groupby/elements-events": "groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978",
+    "@groupby/elements-events": "groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065",
     "lit-element": "^2.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,9 +831,9 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
-"@groupby/elements-events@groupby/elements-events#1696267a35450b9644d3bfa5cfc824bcb2bc8978":
+"@groupby/elements-events@groupby/elements-events#66ab6ebc4b2786f65ffc8ae64d3facbd2e628065":
   version "0.0.0"
-  resolved "https://codeload.github.com/groupby/elements-events/tar.gz/1696267a35450b9644d3bfa5cfc824bcb2bc8978"
+  resolved "https://codeload.github.com/groupby/elements-events/tar.gz/66ab6ebc4b2786f65ffc8ae64d3facbd2e628065"
   dependencies:
     groupby-api "^2.6.2"
     sayt "^0.1.9"


### PR DESCRIPTION
Updating the products responses from Search and SAYT to have identical payloads. Will make writing code and dealing with any search responses easier in the future.