### PR TITLE
ELE-249: Create first pass of tracker service plugin for Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run the `./scripts/setup.sh` script to build all of the Elements-View packages.
 
 ## Demoing
 
-To demo all components and their interaction with the Logic Layer, open `demo/demo.html` in a browser. Note that Beacons functionality will only work if the demo is served with an HTTP server such as [`http-server`](https://www.npmjs.com/package/http-server).
+To demo all components and their interaction with the Logic Layer, open [`demo/demo.html`](demo/demo.html) in a browser. Note that Beacons functionality will only work if the demo is served with an HTTP server such as [`http-server`](https://www.npmjs.com/package/http-server).
 
 ## Commands
 The following commands are run in the context of an individual package contained within the Elements-View monorepo. The individual Web component packages can be found within the [`packages/web-components/@groupby`](packages/web-components/@groupby) directory.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Run the `./scripts/setup.sh` script to build all of the Elements-View packages.
   ./scripts/setup.sh
 ```
 
+## Demoing
+
+To demo all components and their interaction with the Logic Layer, open `demo/demo.html` in a browser. Note that Beacons functionality will only work if the demo is served with an HTTP server such as [`http-server`](https://www.npmjs.com/package/http-server).
+
 ## Commands
 The following commands are run in the context of an individual package contained within the Elements-View monorepo. The individual Web component packages can be found within the [`packages/web-components/@groupby`](packages/web-components/@groupby) directory.
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -93,7 +93,7 @@ if (useQuickStart) {
   'gbe::search_response',
   'gbe::sayt_products_error',
   'gbe::update_search_term',
-  'gbe::tracker::search',
+  'gbe::beacon_search',
 ].forEach(function(eventName) {
   window.addEventListener(eventName, function(event) {
     console.log(event.type, event.detail);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -77,12 +77,13 @@ if (useQuickStart) {
   const cachePlugin = new GbElementsLogic.CachePlugin();
   const cacheDriverPlugin = new GbElementsLogic.CacheDriverPlugin();
   const domEventsPlugin = new GbElementsLogic.DomEventsPlugin();
+  const gbTrackerPlugin = new GbElementsPlugins.GbTrackerPlugin({ customerId: 'apparel', area: 'DemoMaster', collection: 'products' });
   const saytPlugin = new GbElementsLogic.SaytPlugin({ subdomain: customerId });
   const saytDriverPlugin = new GbElementsLogic.SaytDriverPlugin({ productTransformer: productTransformer });
   const searchPlugin = new GbElementsLogic.SearchPlugin({ customerId: customerId });
   const searchDriverPlugin = new GbElementsLogic.SearchDriverPlugin({ productTransformer: searchProductTransformer });
   // register all plugins with core
-  core.register([cachePlugin, cacheDriverPlugin, saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin]);
+  core.register([cachePlugin, cacheDriverPlugin, saytPlugin, saytDriverPlugin, domEventsPlugin, searchPlugin, searchDriverPlugin, gbTrackerPlugin]);
 }
 
 [
@@ -92,6 +93,7 @@ if (useQuickStart) {
   'gbe::search_response',
   'gbe::sayt_products_error',
   'gbe::update_search_term',
+  'gbe::tracker::search',
 ].forEach(function(eventName) {
   window.addEventListener(eventName, function(event) {
     console.log(event.type, event.detail);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -70,6 +70,9 @@ if (useQuickStart) {
   core = GbElementsLogic.quickStart({
     customerId: customerId,
     productTransformer: productTransformer,
+    pluginOptions: {
+      gb_tracker: { area: 'DemoMaster' }
+    }
   });
 } else {
   // init core and plugins
@@ -77,7 +80,7 @@ if (useQuickStart) {
   const cachePlugin = new GbElementsLogic.CachePlugin();
   const cacheDriverPlugin = new GbElementsLogic.CacheDriverPlugin();
   const domEventsPlugin = new GbElementsLogic.DomEventsPlugin();
-  const gbTrackerPlugin = new GbElementsPlugins.GbTrackerPlugin({ customerId: 'apparel', area: 'DemoMaster', collection: 'products' });
+  const gbTrackerPlugin = new GbElementsPlugins.GbTrackerPlugin({ customerId: 'apparel', area: 'DemoMaster' });
   const saytPlugin = new GbElementsLogic.SaytPlugin({ subdomain: customerId });
   const saytDriverPlugin = new GbElementsLogic.SaytDriverPlugin({ productTransformer: productTransformer });
   const searchPlugin = new GbElementsLogic.SearchPlugin({ customerId: customerId });

--- a/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] [minor]
-### Fixed
-- ELE-249: Fixed error where `requestUpdateSearchTerm()` would error if no term is selected.
-
 ### Added
 - ELE-249: Added an `origin` of `'sayt'` in the event payload requesting an update to the search term.
+
+### Fixed
+- ELE-249: Fixed error where `requestUpdateSearchTerm()` would error if no term is selected.
 
 ## [0.1.0] - 2019-11-29
 ### Added

--- a/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ELE-249: Fixed error where `requestUpdateSearchTerm()` would error if no term is selected.
 
 ### Added
-- ELE-249: Passed an `origin` of 'sayt' when triggering an update of the search term.
+- ELE-249: Added an `origin` of `'sayt'` in the event payload requesting an update to the search term.
 
 ## [0.1.0] - 2019-11-29
 ### Added

--- a/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-autocomplete/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Fixed
+- ELE-249: Fixed error where `requestUpdateSearchTerm()` would error if no term is selected.
+
+### Added
+- ELE-249: Passed an `origin` of 'sayt' when triggering an update of the search term.
+
 ## [0.1.0] - 2019-11-29
 ### Added
 - SFX-152: Added the autocomplete component.

--- a/packages/web-components/@groupby/elements-autocomplete/README.md
+++ b/packages/web-components/@groupby/elements-autocomplete/README.md
@@ -47,7 +47,7 @@ This event is dispatched when one of the search terms inside of the `gbe-autocom
 #### `UPDATE_SEARCH_TERM`
 
 This event is dispatched when one of the search terms inside of the `gbe-autocomplete` component is clicked.
-It will contain a flag for emitting a new search.
+It will contain a flag for emitting a new search and an attribute to indicate the the origin of the action was SAYT.
 
 ## Customizations
 

--- a/packages/web-components/@groupby/elements-autocomplete/README.md
+++ b/packages/web-components/@groupby/elements-autocomplete/README.md
@@ -47,7 +47,7 @@ This event is dispatched when one of the search terms inside of the `gbe-autocom
 #### `UPDATE_SEARCH_TERM`
 
 This event is dispatched when one of the search terms inside of the `gbe-autocomplete` component is clicked.
-It will contain a flag for emitting a new search and an attribute to indicate the the origin of the action was SAYT.
+It will contain a flag for emitting a new search and an attribute to indicate the origin of the action was SAYT.
 
 ## Customizations
 

--- a/packages/web-components/@groupby/elements-autocomplete/package.json
+++ b/packages/web-components/@groupby/elements-autocomplete/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@groupby/elements-base": "^0.1.0",
-    "@groupby/elements-events": "^0.1.0",
+    "@groupby/elements-events": "^0.2.0",
     "lit-element": "^2.2.0",
     "lit-html": "^1.1.2",
     "shortid": "^2.2.15"

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -284,6 +284,7 @@ export default class Autocomplete extends Base {
       term: this.selectedItem.label,
       group: this.group,
       search: false,
+      origin: 'sayt',
     };
     this.dispatchElementsEvent(UPDATE_SEARCH_TERM, payload);
   }

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -270,6 +270,7 @@ export default class Autocomplete extends Base {
       term,
       group: this.group,
       search: true,
+      // @TODO Pass origin: 'sayt'
     };
 
     this.dispatchElementsEvent(UPDATE_SEARCH_TERM, payload);

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -280,6 +280,7 @@ export default class Autocomplete extends Base {
    * Emits an [[UPDATE_SEARCH_TERM]] event to update the current search term to the selected autocomplete term.
    */
   requestUpdateSearchTerm(): void {
+    if (!this.selectedItem) return;
     const payload: UpdateSearchTermPayload = {
       term: this.selectedItem.label,
       group: this.group,

--- a/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/src/autocomplete.ts
@@ -270,7 +270,7 @@ export default class Autocomplete extends Base {
       term,
       group: this.group,
       search: true,
-      // @TODO Pass origin: 'sayt'
+      origin: 'sayt',
     };
 
     this.dispatchElementsEvent(UPDATE_SEARCH_TERM, payload);

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -525,6 +525,7 @@ describe('Autcomplete Component', () => {
         group,
         term: autocomplete.selectedItem.label,
         search: false,
+        origin: 'sayt',
       };
       const dispatchElementsEvent = stub(autocomplete, 'dispatchElementsEvent');
 

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -507,6 +507,7 @@ describe('Autcomplete Component', () => {
         term,
         group,
         search: true,
+        origin: 'sayt',
       };
       const dispatchElementsEvent = stub(autocomplete, 'dispatchElementsEvent');
 

--- a/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
+++ b/packages/web-components/@groupby/elements-autocomplete/test/unit/autocomplete.test.ts
@@ -518,6 +518,15 @@ describe('Autcomplete Component', () => {
   });
 
   describe('requestUpdateSearchTerm()', () => {
+    it('should not dispatch an event if nothing is selected', () => {
+      const dispatchElementsEvent = stub(autocomplete, 'dispatchElementsEvent');
+      stub(autocomplete, 'selectedItem').get(() => null);
+
+      autocomplete.requestUpdateSearchTerm();
+
+      expect(dispatchElementsEvent).to.not.be.called;
+    });
+
     it('should dispatch an update search term event', () => {
       const group = autocomplete.group = 'group-1';
       stub(autocomplete, 'selectedItem').get(() => ({ label: 'dress' }));

--- a/packages/web-components/@groupby/elements-sayt/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-sayt/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Added
-- ELE-249: Passed an `origin` of 'sayt' when triggering an update of the search term.
+- ELE-249: Added an `origin` of `'sayt'` in the event payload requesting an update to the search term.
 
 ## [0.1.0] - 2019-11-29
 ### Added

--- a/packages/web-components/@groupby/elements-sayt/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-sayt/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- ELE-249: Passed an `origin` of 'sayt' when triggering an update of the search term.
+
 ## [0.1.0] - 2019-11-29
 ### Added
 - SFX-191: Added the `sayt` component.

--- a/packages/web-components/@groupby/elements-sayt/package.json
+++ b/packages/web-components/@groupby/elements-sayt/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@groupby/elements-base": "^0.1.0",
-    "@groupby/elements-events": "^0.1.0",
+    "@groupby/elements-events": "^0.2.0",
     "@types/debounce": "^1.2.0",
     "debounce": "^1.2.0",
     "lit-element": "^2.2.0",

--- a/packages/web-components/@groupby/elements-sayt/src/sayt.ts
+++ b/packages/web-components/@groupby/elements-sayt/src/sayt.ts
@@ -424,7 +424,6 @@ export default class Sayt extends Base {
    * @param query The search term to use.
    */
   requestSaytProducts(query: string): void {
-    // @TODO Accept origin: string and pass it to dispatchRequestEvent
     this.dispatchRequestEvent(SAYT_PRODUCTS_REQUEST, query);
   }
 
@@ -436,7 +435,6 @@ export default class Sayt extends Base {
    */
   handleAutocompleteTermHover(event: CustomEvent<AutocompleteActiveTermPayload>): void {
     if (this.isCorrectSayt(event)) {
-      // @TODO Pass origin: 'sayt' into debouncedRequestSaytProducts
       this.debouncedRequestSaytProducts(event.detail.query);
     }
   }

--- a/packages/web-components/@groupby/elements-sayt/src/sayt.ts
+++ b/packages/web-components/@groupby/elements-sayt/src/sayt.ts
@@ -402,7 +402,7 @@ export default class Sayt extends Base {
           area: this.area,
           collection: this.collection,
         },
-        // @TODO Add origin key-value here if defined
+        origin: 'sayt',
       },
       bubbles: true,
     });

--- a/packages/web-components/@groupby/elements-sayt/src/sayt.ts
+++ b/packages/web-components/@groupby/elements-sayt/src/sayt.ts
@@ -402,6 +402,7 @@ export default class Sayt extends Base {
           area: this.area,
           collection: this.collection,
         },
+        // @TODO Add origin key-value here if defined
       },
       bubbles: true,
     });
@@ -423,6 +424,7 @@ export default class Sayt extends Base {
    * @param query The search term to use.
    */
   requestSaytProducts(query: string): void {
+    // @TODO Accept origin: string and pass it to dispatchRequestEvent
     this.dispatchRequestEvent(SAYT_PRODUCTS_REQUEST, query);
   }
 
@@ -434,6 +436,7 @@ export default class Sayt extends Base {
    */
   handleAutocompleteTermHover(event: CustomEvent<AutocompleteActiveTermPayload>): void {
     if (this.isCorrectSayt(event)) {
+      // @TODO Pass origin: 'sayt' into debouncedRequestSaytProducts
       this.debouncedRequestSaytProducts(event.detail.query);
     }
   }

--- a/packages/web-components/@groupby/elements-sayt/test/unit/sayt.test.ts
+++ b/packages/web-components/@groupby/elements-sayt/test/unit/sayt.test.ts
@@ -676,6 +676,7 @@ describe('Sayt Component', () => {
             area,
             collection,
           },
+          origin: 'sayt',
         },
         bubbles: true,
       });

--- a/packages/web-components/@groupby/elements-search-box/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-search-box/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] [minor]
 ### Added
-- ELE-249: Accept and pass along `origin` value in search requests from `emitSearchEvent()` and `updateSearch()`.
+- ELE-249: The methods `emitSearchEvent()` and `updateSearch()` now accept and pass along `origin` value in search requests.
 
 ## [0.1.0] - 2019-11-29
 ### Added

--- a/packages/web-components/@groupby/elements-search-box/CHANGELOG.md
+++ b/packages/web-components/@groupby/elements-search-box/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] [minor]
+### Added
+- ELE-249: Accept and pass along `origin` value in search requests from `emitSearchEvent()` and `updateSearch()`.
+
 ## [0.1.0] - 2019-11-29
 ### Added
 - SFX-151: Added the SearchBox component.

--- a/packages/web-components/@groupby/elements-search-box/package.json
+++ b/packages/web-components/@groupby/elements-search-box/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "@groupby/elements-base": "^0.1.0",
-    "@groupby/elements-events": "^0.1.0",
+    "@groupby/elements-events": "^0.2.0",
     "lit-element": "^2.2.0"
   }
 }

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -1,3 +1,4 @@
+import { SendableOrigin } from 'gb-tracker-client/models';
 import {
   customElement,
   html,
@@ -87,7 +88,7 @@ export default class SearchBox extends Base {
    * Dispatches a search request event with the `value` property.
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
-  emitSearchEvent(origin: string = 'search'): void {
+  emitSearchEvent(origin: keyof SendableOrigin = 'search'): void {
     const searchboxRequestEvent = this.createCustomEvent<SearchRequestPayload>(SEARCH_REQUEST, {
       query: this.value,
       config: {

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -160,6 +160,14 @@ export default class SearchBox extends Base {
   }
 
   /**
+   * Triggers an event emission for a search.
+   * Intended for use as an event handler to the Search button.
+   */
+  handleSearchClick(): void {
+    this.emitSearchEvent('search');
+  }
+
+  /**
    * Updates the value property to the value passed to it.
    *
    * @param term The value pulled directly from the input box.
@@ -234,7 +242,7 @@ export default class SearchBox extends Base {
     : ''}
       ${this.searchButton
     ? html`
-            <button class="gbe-submit" @click="${this.emitSearchEvent}">Search</button>
+            <button class="gbe-submit" @click="${this.handleSearchClick}">Search</button>
           `
     : ''}
     `;

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -153,7 +153,6 @@ export default class SearchBox extends Base {
    */
   handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Enter' && this.value.length > 0) {
-      // @TODO For now, assume origin = 'search' (no passing needed)
       // @TODO Future: Determine if Autocomplete term was clicked by checking state
       this.emitSearchEvent();
     }

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import { SendableOrigin } from 'gb-tracker-client/models';
 import {
   customElement,

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -153,7 +153,6 @@ export default class SearchBox extends Base {
    */
   handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Enter' && this.value.length > 0) {
-      // @TODO Future: Determine if Autocomplete term was clicked by checking state
       this.emitSearchEvent();
     }
   }

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -88,13 +88,15 @@ export default class SearchBox extends Base {
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
   emitSearchEvent(): void {
+    // @TODO Accept origin: string parameter that defaults to 'search'
     const searchboxRequestEvent = this.createCustomEvent<SearchRequestPayload>(SEARCH_REQUEST, {
       query: this.value,
       config: {
         area: this.area,
         collection: this.collection,
       },
-    });
+    // @TODO Pass origin property
+  });
     this.dispatchEvent(searchboxRequestEvent);
   }
 
@@ -117,12 +119,14 @@ export default class SearchBox extends Base {
    * @param e The event object.
    */
   updateSearch(e: CustomEvent<UpdateSearchTermPayload>): void {
+    // @TODO Get origin property from event.detail
     const eventGroup = e.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup !== componentGroup) return;
 
     this.updateSearchTermValue(e.detail.term);
     if (e.detail.search) {
+      // @TODO Pass origin argument
       this.emitSearchEvent();
     }
   }
@@ -152,6 +156,8 @@ export default class SearchBox extends Base {
    */
   handleKeydown(e: KeyboardEvent): void {
     if (e.key === 'Enter' && this.value.length > 0) {
+      // @TODO For now, assume origin = 'search' (no passing needed)
+      // @TODO Future: Determine if Autocomplete term was clicked by checking state
       this.emitSearchEvent();
     }
   }

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -66,7 +66,9 @@ export default class SearchBox extends Base {
 
   constructor() {
     super();
+    this.clearSearch = this.clearSearch.bind(this);
     this.updateSearch = this.updateSearch.bind(this);
+    this.handleSearchClick = this.handleSearchClick.bind(this);
   }
 
   /**

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -87,7 +87,7 @@ export default class SearchBox extends Base {
    * Dispatches a search request event with the `value` property.
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
-  emitSearchEvent(): void {
+  emitSearchEvent(origin: string = 'search'): void {
     // @TODO Accept origin: string parameter that defaults to 'search'
     const searchboxRequestEvent = this.createCustomEvent<SearchRequestPayload>(SEARCH_REQUEST, {
       query: this.value,
@@ -95,7 +95,7 @@ export default class SearchBox extends Base {
         area: this.area,
         collection: this.collection,
       },
-      origin: 'search',
+      origin,
     });
     this.dispatchEvent(searchboxRequestEvent);
   }

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -118,15 +118,13 @@ export default class SearchBox extends Base {
    * @param e The event object.
    */
   updateSearch(e: CustomEvent<UpdateSearchTermPayload>): void {
-    // @TODO Get origin property from event.detail
     const eventGroup = e.detail.group || '';
     const componentGroup = this.group || '';
     if (eventGroup !== componentGroup) return;
 
     this.updateSearchTermValue(e.detail.term);
     if (e.detail.search) {
-      // @TODO Pass origin argument
-      this.emitSearchEvent();
+      this.emitSearchEvent(e.detail.origin);
     }
   }
 

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -88,7 +88,6 @@ export default class SearchBox extends Base {
    * Invoked in response to user interactions: `enter` key or click on search button.
    */
   emitSearchEvent(origin: string = 'search'): void {
-    // @TODO Accept origin: string parameter that defaults to 'search'
     const searchboxRequestEvent = this.createCustomEvent<SearchRequestPayload>(SEARCH_REQUEST, {
       query: this.value,
       config: {

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -95,8 +95,8 @@ export default class SearchBox extends Base {
         area: this.area,
         collection: this.collection,
       },
-    // @TODO Pass origin property
-  });
+      // @TODO Pass origin property
+    });
     this.dispatchEvent(searchboxRequestEvent);
   }
 

--- a/packages/web-components/@groupby/elements-search-box/src/search-box.ts
+++ b/packages/web-components/@groupby/elements-search-box/src/search-box.ts
@@ -95,7 +95,7 @@ export default class SearchBox extends Base {
         area: this.area,
         collection: this.collection,
       },
-      // @TODO Pass origin property
+      origin: 'search',
     });
     this.dispatchEvent(searchboxRequestEvent);
   }

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -256,7 +256,7 @@ describe('SearchBox Component', () => {
   });
 
   describe('handleSearchClick', () => {
-    it('should trigger a search event to be omitted with an origin of search', () => {
+    it('should trigger a search event to be emitted with an origin of search', () => {
       const emitSearchEvent = stub(searchbox, 'emitSearchEvent');
 
       searchbox.handleSearchClick();

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -101,12 +101,18 @@ describe('SearchBox Component', () => {
   });
 
   describe('emitSearchEvent', () => {
-    const origin = 'search';
+    const area = 'some-area';
+    const collection = 'some-collection';
+    let origin;
+    let query;
+
+    beforeEach(() => {
+      origin = 'search';
+      searchbox.id = 'some-id';
+      query = searchbox.value = 'a';
+    });
 
     it('should dispatch a search request event with empty area and collection', () => {
-      const query = searchbox.value = 'a';
-      searchbox.id = 'some-id';
-
       searchbox.emitSearchEvent();
 
       expect(createCustomEvent).to.be.calledWith(SEARCH_REQUEST, {
@@ -121,12 +127,28 @@ describe('SearchBox Component', () => {
     });
 
     it('should dispatch a search request event with area and collection', () => {
-      const query = searchbox.value = 'a';
-      const area = searchbox.area = 'some-area';
-      const collection = searchbox.collection = 'some-collection';
-      searchbox.id = 'some-id';
+      searchbox.area = area;
+      searchbox.collection = collection;
 
       searchbox.emitSearchEvent();
+
+      expect(createCustomEvent).to.be.calledWith(SEARCH_REQUEST, {
+        query,
+        config: {
+          area,
+          collection,
+        },
+        origin,
+      });
+      expect(searchboxDispatchEvent).to.be.calledWith(eventObject);
+    });
+
+    it('should dispatch a search request event with the passed origin', () => {
+      searchbox.area = area;
+      searchbox.collection = collection;
+      origin = 'sayt';
+
+      searchbox.emitSearchEvent(origin);
 
       expect(createCustomEvent).to.be.calledWith(SEARCH_REQUEST, {
         query,

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -103,7 +103,6 @@ describe('SearchBox Component', () => {
   describe('emitSearchEvent', () => {
     const area = 'some-area';
     const collection = 'some-collection';
-    let origin;
     let query;
 
     beforeEach(() => {
@@ -121,7 +120,7 @@ describe('SearchBox Component', () => {
           area: '',
           collection: '',
         },
-        origin,
+        origin: 'search',
       });
       expect(searchboxDispatchEvent).to.be.calledWith(eventObject);
     });
@@ -138,7 +137,7 @@ describe('SearchBox Component', () => {
           area,
           collection,
         },
-        origin,
+        origin: 'search',
       });
       expect(searchboxDispatchEvent).to.be.calledWith(eventObject);
     });
@@ -146,7 +145,7 @@ describe('SearchBox Component', () => {
     it('should dispatch a search request event with the passed origin', () => {
       searchbox.area = area;
       searchbox.collection = collection;
-      origin = 'sayt';
+      const origin = 'sayt';
 
       searchbox.emitSearchEvent(origin);
 

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -195,7 +195,12 @@ describe('SearchBox Component', () => {
       const search = true;
       const origin = 'navigation';
       const inputEvent = new CustomEvent('some-test-type', {
-        detail: { term, group, search, origin },
+        detail: {
+          term,
+          group,
+          search,
+          origin,
+        },
       });
       searchbox.group = group;
 

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -101,6 +101,8 @@ describe('SearchBox Component', () => {
   });
 
   describe('emitSearchEvent', () => {
+    const origin = 'search';
+
     it('should dispatch a search request event with empty area and collection', () => {
       const query = searchbox.value = 'a';
       searchbox.id = 'some-id';
@@ -113,6 +115,7 @@ describe('SearchBox Component', () => {
           area: '',
           collection: '',
         },
+        origin,
       });
       expect(searchboxDispatchEvent).to.be.calledWith(eventObject);
     });
@@ -131,6 +134,7 @@ describe('SearchBox Component', () => {
           area,
           collection,
         },
+        origin,
       });
       expect(searchboxDispatchEvent).to.be.calledWith(eventObject);
     });

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -191,14 +191,17 @@ describe('SearchBox Component', () => {
       expect(updateSearchTermValue).to.be.calledWith(term);
     });
 
-    it('should emit a search request if event requests it and group matches', () => {
+    it('should emit a search request with origin if event requests it and group matches', () => {
       const search = true;
-      const inputEvent = new CustomEvent('some-test-type', { detail: { term, group, search } });
+      const origin = 'navigation';
+      const inputEvent = new CustomEvent('some-test-type', {
+        detail: { term, group, search, origin },
+      });
       searchbox.group = group;
 
       searchbox.updateSearch(inputEvent);
 
-      expect(emitSearchEvent).to.be.calledOnce;
+      expect(emitSearchEvent).to.be.calledOnceWith(origin);
     });
 
     it('should not update the value or emit a search when the group in the component and the event do not match', () => {

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -255,6 +255,16 @@ describe('SearchBox Component', () => {
     });
   });
 
+  describe('handleSearchClick', () => {
+    it('should trigger a search event to be omitted with an origin of search', () => {
+      const emitSearchEvent = stub(searchbox, 'emitSearchEvent');
+
+      searchbox.handleSearchClick();
+
+      expect(emitSearchEvent).to.be.calledOnceWith('search');
+    });
+  });
+
   describe('handleInput', () => {
     it('should invoke the updateSearchTermValue function with a value from the event', () => {
       const updateSearchTermValueStub = stub(searchbox, 'updateSearchTermValue');

--- a/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
+++ b/packages/web-components/@groupby/elements-search-box/test/unit/search-box.test.ts
@@ -106,7 +106,6 @@ describe('SearchBox Component', () => {
     let query;
 
     beforeEach(() => {
-      origin = 'search';
       searchbox.id = 'some-id';
       query = searchbox.value = 'a';
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,11 +831,30 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
+"@groupby/beacon-models@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@groupby/beacon-models/-/beacon-models-2.0.3.tgz#d1d80149284090c15cc11723a6c91d73b3e0f12a"
+  integrity sha512-XkD6Y7F1AhyllXL3ZWbrV2EfD9LHiXWkO5vO+Lzo/brK/6REBJK15xcwL2rc2uTeQDXfmjutf0oC/lJFhRBQCQ==
+  dependencies:
+    "@types/lodash" "^4.14.123"
+    lodash "^4.17.11"
+    moment "^2.22.2"
+    regexpu-core "^4.2.0"
+
 "@groupby/elements-events@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@groupby/elements-events/-/elements-events-0.1.0.tgz#dc15c8535205ee5da0f31258764329a4f502286f"
   integrity sha512-kvYUGBMvGmhmNL1rCa6SPGbR6hS4RiKz+KNjbfvQTQDtgFDsuaDi4Yu8lHSlw4eQBZQCT9QOgpJCzN1CTa08HQ==
   dependencies:
+    groupby-api "^2.6.2"
+    sayt "^0.1.9"
+
+"@groupby/elements-events@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@groupby/elements-events/-/elements-events-0.2.0.tgz#9b0e8d0146e6d28743b9b23b53b4c6f7ba7ea694"
+  integrity sha512-ng/LEC3Bpzu3ufz/nr9E2WcS3Dc33xuqibwAAXM5iDYXwWSkpXBRQUbnEGCkPcWHy2uuBaFXbUelzG9lgDxsOw==
+  dependencies:
+    gb-tracker-client "^3.7.2"
     groupby-api "^2.6.2"
     sayt "^0.1.9"
 
@@ -1352,10 +1371,20 @@
   resolved "https://registry.yarnpkg.com/@types/clone/-/clone-0.1.30.tgz#e7365648c1b42136a59c7d5040637b3b5c83b614"
   integrity sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=
 
+"@types/cuid@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/cuid/-/cuid-1.3.0.tgz#20b0e00ca555df564866bc52d2e251bf90c88db7"
+  integrity sha1-ILDgDKVV31ZIZrxS0uJRv5DIjbc=
+
 "@types/debounce@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/debounce/-/debounce-1.2.0.tgz#9ee99259f41018c640b3929e1bb32c3dcecdb192"
   integrity sha512-bWG5wapaWgbss9E238T0R6bfo5Fh3OkeoSt245CM7JJwVwpw6MEBCbIxLq5z8KzsE3uJhzcIuQkyiZmzV3M/Dw==
+
+"@types/deep-diff@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/deep-diff/-/deep-diff-1.0.0.tgz#7eba3202a99b3a207f758f351f7f86387269fc40"
+  integrity sha512-ENsJcujGbCU/oXhDfQ12mSo/mCBWodT2tpARZKmatoSrf8+cGRCPi0KVj3I0FORhYZfLXkewXu7AoIWqiBLkNw==
 
 "@types/deep-equal@^0.0.30":
   version "0.0.30"
@@ -1429,6 +1458,16 @@
   version "4.14.147"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.147.tgz#8ca5cfa9c67753dcb73e507d1bbf1c4f8ba6f029"
   integrity sha512-+0zY1Axql6ru5T85Rh6aR6Zr0xT7c0USLqsHv01b3ID//dOrV3OvpXJGjm69+4QpxoZ0oMNEfmW1ltwXe2WVzQ==
+
+"@types/lodash@^4.14.123":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/lz-string@^1.3.33":
+  version "1.3.33"
+  resolved "https://registry.yarnpkg.com/@types/lz-string/-/lz-string-1.3.33.tgz#de2d6105ea7bcaf67dd1d9451d580700d30473fc"
+  integrity sha512-yWj3OnlKlwNpq9+Jh/nJkVAD3ta8Abk2kIRpjWpVkDlAD43tn6Q6xk5hurp84ndcq54jBDBGCD/WcIR0pspG0A==
 
 "@types/marked@^0.4.0":
   version "0.4.2"
@@ -2215,6 +2254,11 @@ async@0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.6.tgz#ad3f373d9249ae324881565582bc90e152abbd68"
   integrity sha1-rT83PZJJrjJIgVZVgryQ4VKrvWg=
+
+async@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.6.2:
   version "2.6.3"
@@ -4194,6 +4238,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookies-js@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/cookies-js/-/cookies-js-1.2.3.tgz#03315049e7c52bee3f73186a69167eab0ddb2d31"
+  integrity sha1-AzFQSefFK+4/cxhqaRZ+qw3bLTE=
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -4443,6 +4492,11 @@ csstype@^2.2.0, csstype@^2.5.7:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
+cuid@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.6.tgz#dc3a20b5a7497d36d32c0bf8a2997524c9c796c4"
+  integrity sha512-ZFp7PS6cSYMJNch9fc3tyHdE4T8TDo3Y5qAxb0KSA9mpiYDo7z9ql1CznFuuzxea9STVIDy0tJWm2lYiX2ZU1Q==
+
 cuint@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
@@ -4546,6 +4600,11 @@ dedent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.6.0.tgz#0e6da8f0ce52838ef5cec5c8f9396b0c1b64a3cb"
   integrity sha1-Dm2o8M5Sg471zsXI+TlrDBtko8s=
+
+deep-diff@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-1.0.2.tgz#afd3d1f749115be965e89c63edc7abb1506b9c26"
+  integrity sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==
 
 deep-eql@^3.0.1:
   version "3.0.1"
@@ -6195,6 +6254,21 @@ gaze@^1.0.0:
   integrity sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==
   dependencies:
     globule "^1.0.0"
+
+gb-tracker-client@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/gb-tracker-client/-/gb-tracker-client-3.7.2.tgz#2bdcdb7535705b974a94b128548fbf008ecfd393"
+  integrity sha512-nXAZkOq4UFC2wpFj2COx8wWeM9U12sN5bDCd7sqjJ3vUkfk+tzsM5BXjebXYN+Nx2qD644xuEHcvIkN5os8TPA==
+  dependencies:
+    "@groupby/beacon-models" "^2.0.3"
+    "@types/cuid" "^1.3.0"
+    "@types/deep-diff" "^1.0.0"
+    "@types/lz-string" "^1.3.33"
+    cookies-js "^1.2.3"
+    cuid "^2.1.6"
+    deep-diff "^1.0.2"
+    lz-string "^1.4.4"
+    schema-inspector "^1.6.8"
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -8238,6 +8312,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 make-dir@^1.0.0, make-dir@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -8638,7 +8717,7 @@ moment-duration-format-commonjs@^1.0.0:
   resolved "https://registry.yarnpkg.com/moment-duration-format-commonjs/-/moment-duration-format-commonjs-1.0.0.tgz#dc5de612e6d6ff41f774d03772a139a363563bc3"
   integrity sha512-MVFR4hIh4jfuwSCPBEE5CCwn3refvTsxK/Yv/DpKJ6YcNnCimlVJ6DQeTJG1KVQPw1o8m3tkbHE9gVjivyv9iA==
 
-moment@^2.10.3, moment@^2.14.1, moment@^2.18.1:
+moment@^2.10.3, moment@^2.14.1, moment@^2.18.1, moment@^2.22.2:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
@@ -10567,7 +10646,7 @@ regexpu-core@^2.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-regexpu-core@^4.6.0:
+regexpu-core@^4.2.0, regexpu-core@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.6.0.tgz#2037c18b327cfce8a6fea2a4ec441f2432afb8b6"
   integrity sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==
@@ -10942,6 +11021,13 @@ scheduler@^0.17.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+schema-inspector@^1.6.8:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/schema-inspector/-/schema-inspector-1.6.8.tgz#b9e53983cc55ff2dbd7b65e3dbe085d9d1285f2a"
+  integrity sha1-ueU5g8xV/y29e2Xj2+CF2dEoXyo=
+  dependencies:
+    async "^1.5.0"
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
* Update README to explain how to demo the View and Logic Layers.
* Update demo to register the `GbTrackerPlugin` and log beacons to the console.
* Update Autocomplete component:
  * Fix error where `requestUpdateSearchTerm()` would error if no term is selected.
  * Pass `origin: sayt` where possible for beaconing.
* Update Sayt component to pass `origin: sayt` where possible for beaconing.
* Update Searchbox component:
  * Accept `origin` in `emitSearchEvent()` and pass it along.
  * Pass along `origin` from the passed event in `updateSearch()`.
* Refactor some tests.
